### PR TITLE
fix jar build, argument handling fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,3 +12,10 @@ dependencies {
     compile 'org.ow2.asm:asm:5.0.2'
     compile 'com.google.code.gson:gson:2.2.4'
 }
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'gr.watchful.moddetectorapi.main'
+    }
+    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+}

--- a/src/main/java/gr/watchful/moddetectorapi/main.java
+++ b/src/main/java/gr/watchful/moddetectorapi/main.java
@@ -28,8 +28,10 @@ public class main {
         File folder = null;
         File oldFolder = null;
         for(String arg : args) {
-            if(arg.equals("-v")) {
+            if(arg.equals("-v") || arg.equals("--verbose")) {
                 logger.logLevel = Logger.INFO;
+            } else if(arg.equals("-h") || arg.equals("--help")) {
+                logger.message("do not use " + arg + " with other arguments, ignoring");
             } else if(!onSecondFolder) {
                 folder = new File(arg);
                 onSecondFolder = true;
@@ -38,13 +40,19 @@ public class main {
             }
         }
 
-        if(oldFolder != null && !oldFolder.exists()) {
-            logger.error("Folder does not exist, aborting: " + oldFolder.getPath());
+        if(folder == null) {
+            logger.error("No folder given, aborting");
             return;
         }
 
-        if(folder == null || !folder.exists()) {
+        if(!folder.exists())
+        {
             logger.error("Folder does not exist, aborting: " + folder.getPath());
+            return;
+        }
+
+        if(oldFolder != null && !oldFolder.exists()) {
+            logger.error("Folder does not exist, aborting: " + oldFolder.getPath());
             return;
         }
 


### PR DESCRIPTION
A self-built jar was incomplete, missing dependencies and a proper manifest (no main-class defined).
I also added some stupidity-proofing to the argument handling. For example, calling it with "-v" and no other argument yielded a NPE.
